### PR TITLE
Update to self hosted GHA runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - completed
 jobs:
   report:
-    runs-on: ubuntu-latest
+    runs-on: general-purpose
     steps:
     - uses: dorny/test-reporter@v1
       with:

--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   terratest:
     name: Run Terratest
-    runs-on: ubuntu-latest
+    runs-on: general-purpose
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 jobs:
   tflint:
     name: runner / tflint
-    runs-on: ubuntu-latest
+    runs-on: general-purpose
 
     steps:
       - name: Clone repo


### PR DESCRIPTION
Updating from the GHA cloud runner instance to our own self hosted runners, the cost of cloud runners is ~4x what we spend to self host.

[_Created by Sourcegraph batch change `NoHesHere/update-to-general-purpose`._](https://sourcegraph.build.dox.pub/users/NoHesHere/batch-changes/update-to-general-purpose)